### PR TITLE
rename: name changes for move to openstack-network-exporter repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/dataplane-node-exporter*
+/openstack-network-exporter*
 /cert.pem
 /key.pem
 /ovsdb/ovs/*.go

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -19,10 +19,10 @@ requre-specific = true # linter exceptions must specify the linter
 
 [linters-settings.govet.settings.printf]
 funcs = [
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log.Debugf",
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log.Infof",
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log.Noticef",
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log.Warnf",
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log.Errf",
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log.Critf",
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log.Debugf",
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log.Infof",
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log.Noticef",
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log.Warnf",
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log.Errf",
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log.Critf",
 ]

--- a/Containerfile
+++ b/Containerfile
@@ -6,16 +6,16 @@ RUN dnf install -y --nodocs --setopt=install_weak_deps=0 go
 
 FROM build_base AS build
 ADD . /src
-RUN cd /src && go generate ./... && go build -trimpath -o dataplane-node-exporter
+RUN cd /src && go generate ./... && go build -trimpath -o openstack-network-exporter
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS ubi_minimal
 RUN microdnf update -y && rm -rf /var/cache/yum
 RUN microdnf install -y iproute && microdnf clean all
 
 FROM ubi_minimal
-COPY --from=build /src/etc/dataplane-node-exporter.yaml /etc/dataplane-node-exporter.yaml
-COPY --from=build /src/dataplane-node-exporter /app/dataplane-node-exporter
+COPY --from=build /src/etc/openstack-network-exporter.yaml /etc/openstack-network-exporter.yaml
+COPY --from=build /src/openstack-network-exporter /app/openstack-network-exporter
 
 MAINTAINER Red Hat
 EXPOSE 1981
-CMD ["/app/dataplane-node-exporter"]
+CMD ["/app/openstack-network-exporter"]

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ version = $(shell git describe --long --abbrev=12 --tags --dirty 2>/dev/null || 
 src = $(shell find * -type f -name '*.go') go.mod go.sum
 
 # Image URL to use all building/pushing image targets
-DEFAULT_IMG ?= quay.io/openstack-k8s-operators/dataplane-node-exporter:$(version)
-# Development: quay.io/user/dataplane-node-exporter:latest
+DEFAULT_IMG ?= quay.io/openstack-k8s-operators/openstack-network-exporter:$(version)
+# Development: quay.io/user/openstack-network-exporter:latest
 IMG ?= $(DEFAULT_IMG)
 
 .PHONY: all
-all: dataplane-node-exporter
+all: openstack-network-exporter
 
-dataplane-node-exporter: $(src) ovsdb/ovs/model.go
+openstack-network-exporter: $(src) ovsdb/ovs/model.go
 	go build -trimpath -o $@
 
 .PHONY: generate
@@ -22,9 +22,9 @@ ovsdb/ovs/model.go: ovsdb/ovs/schema.json
 	go generate ./...
 
 .PHONY: debug
-debug: dataplane-node-exporter.debug
+debug: openstack-network-exporter.debug
 
-dataplane-node-exporter.debug: $(src) ovsdb/ovs/model.go
+openstack-network-exporter.debug: $(src) ovsdb/ovs/model.go
 	go build -gcflags=all="-N -l" -o $@
 
 .PHONY: format
@@ -50,8 +50,8 @@ cert.pem key.pem:
 		-subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=CommonNameOrHostname"
 
 .PHONY: run
-run: dataplane-node-exporter cert.pem key.pem
-	DATAPLANE_NODE_EXPORTER_YAML=etc/dev.yaml ./$<
+run: openstack-network-exporter cert.pem key.pem
+	OPENSTACK_NETWORK_EXPORTER_YAML=etc/dev.yaml ./$<
 
 .PHONY: container
 container:
@@ -69,5 +69,5 @@ tag-release:
 	if [ -n "$$n" ]; then next_version="$$n"; fi && \
 	set -xe && \
 	sed -i "s/\<v$$cur_version\>/v$$next_version/" Makefile && \
-	git commit -sm "dataplane-node-exporter: release v$$next_version" -m "`git shortlog -sn v$$cur_version..`" Makefile && \
+	git commit -sm "openstack-network-exporter: release v$$next_version" -m "`git shortlog -sn v$$cur_version..`" Makefile && \
 	git tag -sm "v$$next_version" "v$$next_version"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Dataplane Node Exporter
+# OpenStack Network Exporter
 
 This is a prometheus exporter for dataplane (compute, network) nodes running
 with OpenvSwitch. It supports the default linux kernel and userspace DPDK data
 paths.
 
-The Dataplane Node Exporter is distributed under the [Apache 2.0][license]
+The OpenStack Network Exporter is distributed under the [Apache 2.0][license]
 license.
 
 [license]: https://spdx.org/licenses/Apache-2.0.html
@@ -21,16 +21,16 @@ make
 ## Configuration
 
 By default, the configuration will be loaded from a YAML file located at
-`/etc/dataplane-node-exporter.yaml`. If the file does not exist, the default
+`/etc/openstack-network-exporter.yaml`. If the file does not exist, the default
 configuration will be used.
 
 The location of the configuration file can be changed via the
-`DATAPLANE_NODE_EXPORTER_YAML` environment variable.
+`OPENSTACK_NETWORK_EXPORTER_YAML` environment variable.
 
 The default configuration file can be found in the git repository:
-[`dataplane-node-exporter.yaml`][conf].
+[`openstack-network-exporter.yaml`][conf].
 
-[conf]: https://github.com/openstack-k8s-operators/dataplane-node-exporter/blob/main/etc/dataplane-node-exporter.yaml
+[conf]: https://github.com/openstack-k8s-operators/openstack-network-exporter/blob/main/etc/openstack-network-exporter.yaml
 
 ## Running
 
@@ -53,7 +53,7 @@ The bridge collector will need access to each bridge OpenFlow management socket
 located at `/run/openvswitch/$BRIDGE_NAME.mgmt`.
 
 ```console
-$ ./dataplane-node-exporter
+$ ./openstack-network-exporter
 NOTICE  14:49:18 main.go:86: listening on http://:1981/metrics
 ```
 
@@ -62,7 +62,7 @@ NOTICE  14:49:18 main.go:86: listening on http://:1981/metrics
 The complete list of supported metrics can be displayed using the `-l` flag:
 
 ```console
-$ ./dataplane-node-exporter -l
+$ ./openstack-network-exporter -l
 ovs_bridge_port_count collector=bridge set=base type=gauge labels=bridge,datapath_type help="The number of ports in a bridge."
 ovs_bridge_flow_count collector=bridge set=base type=gauge labels=bridge,datapath_type help="The number of openflow rules configured on a bridge."
 ...
@@ -78,18 +78,18 @@ to point at your fork and keep a reference on the upstream repository. You can
 also take the opportunity to configure git to use SSH for pushing and https://
 for pulling.
 
-[fork]: https://github.com/openstack-k8s-operators/dataplane-node-exporter/fork
+[fork]: https://github.com/openstack-k8s-operators/openstack-network-exporter/fork
 
 ```console
 $ git remote remove origin
-$ git remote add upstream https://github.com/openstack-k8s-operators/dataplane-node-exporter
-$ git remote add origin https://github.com/rjarry/dataplane-node-exporter
+$ git remote add upstream https://github.com/openstack-k8s-operators/openstack-network-exporter
+$ git remote add origin https://github.com/rjarry/openstack-network-exporter
 $ git fetch --all
 Fetching origin
-From https://github.com/rjarry/dataplane-node-exporter
+From https://github.com/rjarry/openstack-network-exporter
  * [new branch]                main       -> origin/main
 Fetching upstream
-From https://github.com/openstack-k8s-operators/dataplane-node-exporter
+From https://github.com/openstack-k8s-operators/openstack-network-exporter
  * [new branch]                main       -> upstream/main
 $ git config url.git@github.com:.pushinsteadof https://github.com/
 ```
@@ -181,9 +181,9 @@ Total 6 (delta 5), reused 0 (delta 0), pack-reused 0 (from 0)
 remote: Resolving deltas: 100% (5/5), completed with 5 local objects.
 remote:
 remote: Create a pull request for 'irq-counters' on GitHub by visiting:
-remote:      https://github.com/rjarry/dataplane-node-exporter/pull/new/irq-counters
+remote:      https://github.com/rjarry/openstack-network-exporter/pull/new/irq-counters
 remote:
-To github.com:rjarry/dataplane-node-exporter
+To github.com:rjarry/openstack-network-exporter
  * [new branch]                irq-counters -> irq-counters
 ```
 

--- a/appctl/appctl.go
+++ b/appctl/appctl.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 )
 
 type appctlDaemon string

--- a/collectors/bridge/collector.go
+++ b/collectors/bridge/collector.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb/ovs"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/bridge/metrics.go
+++ b/collectors/bridge/metrics.go
@@ -4,11 +4,11 @@
 package bridge
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/openflow"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb/ovs"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/openflow"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/collectors.go
+++ b/collectors/collectors.go
@@ -4,16 +4,16 @@
 package collectors
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/bridge"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/coverage"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/datapath"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/iface"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/memory"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/ovn"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/pmd_perf"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/pmd_rxq"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/vswitch"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/bridge"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/coverage"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/datapath"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/iface"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/memory"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/ovn"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/pmd_perf"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/pmd_rxq"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/vswitch"
 )
 
 // All supported collectors. Please keep alpha sorted.

--- a/collectors/coverage/collector.go
+++ b/collectors/coverage/collector.go
@@ -9,10 +9,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/appctl"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/appctl"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/coverage/metrics.go
+++ b/collectors/coverage/metrics.go
@@ -4,8 +4,8 @@
 package coverage
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/datapath/collector.go
+++ b/collectors/datapath/collector.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/appctl"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/appctl"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/datapath/metrics.go
+++ b/collectors/datapath/metrics.go
@@ -4,8 +4,8 @@
 package datapath
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/iface/collector.go
+++ b/collectors/iface/collector.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb/ovs"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/iface/metrics.go
+++ b/collectors/iface/metrics.go
@@ -3,9 +3,9 @@ package iface
 import (
 	"fmt"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb/ovs"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/lib/metric.go
+++ b/collectors/lib/metric.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/memory/collector.go
+++ b/collectors/memory/collector.go
@@ -7,10 +7,10 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/appctl"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/appctl"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/memory/metrics.go
+++ b/collectors/memory/metrics.go
@@ -4,8 +4,8 @@
 package memory
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/ovn/collector.go
+++ b/collectors/ovn/collector.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/appctl"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb/ovs"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/appctl"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/ovn/metrics.go
+++ b/collectors/ovn/metrics.go
@@ -1,8 +1,8 @@
 package ovn
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/pmd_perf/collector.go
+++ b/collectors/pmd_perf/collector.go
@@ -9,10 +9,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/appctl"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/appctl"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/pmd_perf/metrics.go
+++ b/collectors/pmd_perf/metrics.go
@@ -4,8 +4,8 @@
 package pmd_perf
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/pmd_rxq/collector.go
+++ b/collectors/pmd_rxq/collector.go
@@ -13,10 +13,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/appctl"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/appctl"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/pmd_rxq/metrics.go
+++ b/collectors/pmd_rxq/metrics.go
@@ -4,8 +4,8 @@
 package pmd_rxq
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/vswitch/collector.go
+++ b/collectors/vswitch/collector.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb/ovs"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collectors/vswitch/metrics.go
+++ b/collectors/vswitch/metrics.go
@@ -4,9 +4,9 @@
 package vswitch
 
 import (
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb/ovs"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -10,11 +10,11 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 	"gopkg.in/yaml.v3"
 )
 
-const defaultConfigPath = "/etc/dataplane-node-exporter.yaml"
+const defaultConfigPath = "/etc/openstack-network-exporter.yaml"
 
 type MetricSet uint
 
@@ -58,16 +58,16 @@ type user struct {
 }
 
 type conf struct {
-	HttpListen string            `yaml:"http-listen" env:"DATAPLANE_NODE_EXPORTER_HTTP_LISTEN"`
-	HttpPath   string            `yaml:"http-path" env:"DATAPLANE_NODE_EXPORTER_HTTP_PATH"`
-	TlsCert    string            `yaml:"tls-cert" env:"DATAPLANE_NODE_EXPORTER_TLS_CERT"`
-	TlsKey     string            `yaml:"tls-key" env:"DATAPLANE_NODE_EXPORTER_TLS_KEY"`
+	HttpListen string            `yaml:"http-listen" env:"OPENSTACK_NETWORK_EXPORTER_HTTP_LISTEN"`
+	HttpPath   string            `yaml:"http-path" env:"OPENSTACK_NETWORK_EXPORTER_HTTP_PATH"`
+	TlsCert    string            `yaml:"tls-cert" env:"OPENSTACK_NETWORK_EXPORTER_TLS_CERT"`
+	TlsKey     string            `yaml:"tls-key" env:"OPENSTACK_NETWORK_EXPORTER_TLS_KEY"`
 	AuthUsers  []user            `yaml:"auth-users"`
 	users      map[string]string `yaml:"-"`
-	OvsRundir  string            `yaml:"ovs-rundir" env:"DATAPLANE_NODE_EXPORTER_OVS_RUNDIR"`
-	OvnRundir  string            `yaml:"ovn-rundir" env:"DATAPLANE_NODE_EXPORTER_OVN_RUNDIR"`
-	OvsProcdir string            `yaml:"ovs-procdir" env:"DATAPLANE_NODE_EXPORTER_OVS_PROCDIR"`
-	LogLevel   string            `yaml:"log-level" env:"DATAPLANE_NODE_EXPORTER_LOG_LEVEL"`
+	OvsRundir  string            `yaml:"ovs-rundir" env:"OPENSTACK_NETWORK_EXPORTER_OVS_RUNDIR"`
+	OvnRundir  string            `yaml:"ovn-rundir" env:"OPENSTACK_NETWORK_EXPORTER_OVN_RUNDIR"`
+	OvsProcdir string            `yaml:"ovs-procdir" env:"OPENSTACK_NETWORK_EXPORTER_OVS_PROCDIR"`
+	LogLevel   string            `yaml:"log-level" env:"OPENSTACK_NETWORK_EXPORTER_LOG_LEVEL"`
 	logLevel   syslog.Priority   `yaml:"-"`
 	Collectors []string          `yaml:"collectors"`
 	MetricSets []string          `yaml:"metric-sets"`
@@ -97,7 +97,7 @@ func AuthUsers() map[string]string { return c.users }
 func MetricSets() MetricSet        { return c.metricSets }
 
 func Parse() error {
-	path, configInEnv := os.LookupEnv("DATAPLANE_NODE_EXPORTER_YAML")
+	path, configInEnv := os.LookupEnv("OPENSTACK_NETWORK_EXPORTER_YAML")
 	if !configInEnv {
 		path = defaultConfigPath
 	}

--- a/etc/openstack-network-exporter.yaml
+++ b/etc/openstack-network-exporter.yaml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Robin Jarry
 #
-# This is the configuration file for OpenStack dataplane-node-exporter. It is
+# This is the configuration file for OpenStack openstack-network-exporter. It is
 # written in the YAML format. The exporter will lookup the configuration file
-# at /etc/dataplane-node-exporter.yaml by default. The path can be changed via
-# the DATAPLANE_NODE_EXPORTER_YAML environment variable.
+# at /etc/openstack-network-exporter.yaml by default. The path can be changed via
+# the OPENSTACK_NETWORK_EXPORTER_YAML environment variable.
 #
 # All settings have default values and some of them can be overriden via
 # environment variables as indicated in their description.
@@ -14,28 +14,28 @@
 # "127.0.0.1:<port>" or "[::1]:<port>" to limit to localhost. If address is
 # omited, listen on all addresses.
 #
-# Env: DATAPLANE_NODE_EXPORTER_HTTP_LISTEN
+# Env: OPENSTACK_NETWORK_EXPORTER_HTTP_LISTEN
 # Default: ":1981"
 #
 #http-listen: ":1981"
 
 # The HTTP path where to serve responses to prometheus scrapers.
 #
-# Env: DATAPLANE_NODE_EXPORTER_HTTP_PATH
+# Env: OPENSTACK_NETWORK_EXPORTER_HTTP_PATH
 # Default: /metrics
 #
 #http-path: /metrics
 
 # The path to a TLS certificate to enable HTTPS support.
 #
-# Env: DATAPLANE_NODE_EXPORTER_TLS_CERT
+# Env: OPENSTACK_NETWORK_EXPORTER_TLS_CERT
 # Default: ""
 #
 #tls-cert:
 
 # The path to a TLS certificate secret key to enable HTTPS support.
 #
-# Env: DATAPLANE_NODE_EXPORTER_TLS_KEY
+# Env: OPENSTACK_NETWORK_EXPORTER_TLS_KEY
 # Default: ""
 #
 #tls-key:
@@ -61,7 +61,7 @@
 #
 # Supported levels are: debug info notice warning error critical
 #
-# Env: DATAPLANE_NODE_EXPORTER_LOG_LEVEL
+# Env: OPENSTACK_NETWORK_EXPORTER_LOG_LEVEL
 # Default: notice
 #
 #log-level: notice
@@ -70,7 +70,7 @@
 # expected to contain the the ovn-controller pid file "ovn-controller.pid" and
 # its unixctl socket "ovn-controller.$pid.ctl".
 #
-# Env: DATAPLANE_NODE_EXPORTER_OVN_RUNDIR
+# Env: OPENSTACK_NETWORK_EXPORTER_OVN_RUNDIR
 # Default: /run/ovn
 #
 #ovn-rundir: /run/ovn
@@ -80,7 +80,7 @@
 # "ovs-vswitchd.pid" file and each bridge openflow management sockets
 # "$bridge_name.mgmt".
 #
-# Env: DATAPLANE_NODE_EXPORTER_OVS_RUNDIR
+# Env: OPENSTACK_NETWORK_EXPORTER_OVS_RUNDIR
 # Default: /run/openvswitch
 #
 #ovs-rundir: /run/openvswitch
@@ -89,13 +89,13 @@
 # ovs-vswitchd.pid. When running the exporter in a different PID namespace than
 # OVS, this will need to be changed to another folder.
 #
-# Env: DATAPLANE_NODE_EXPORTER_OVS_PROCDIR
+# Env: OPENSTACK_NETWORK_EXPORTER_OVS_PROCDIR
 # Default: /proc
 #
 #ovs-procdir: /proc
 
 # List of metric collectors to scrape and export. To list the available
-# collectors and the metrics they export, use "dataplane-node-exporter -l". If
+# collectors and the metrics they export, use "openstack-network-exporter -l". If
 # the list is empty (default) all collectors will be enabled.
 #
 # Default: []
@@ -103,7 +103,7 @@
 #collectors: []
 
 # List of metric sets to export. This is cumulative with the collectors option.
-# The "dataplane-node-exporter -l" flag will list all supported metrics along
+# The "openstack-network-exporter -l" flag will list all supported metrics along
 # with their set name. If the list is empty (default) all metrics from enabled
 # collectors will be exported.
 #

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2024 Robin Jarry
 
-module github.com/openstack-k8s-operators/dataplane-node-exporter
+module github.com/openstack-k8s-operators/openstack-network-exporter
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/collectors/lib"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/collectors/lib"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/openflow/openflow.go
+++ b/openflow/openflow.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
 )
 
 // required constants taken from openvswitch

--- a/ovsdb/ovsdb.go
+++ b/ovsdb/ovsdb.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/config"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/log"
-	"github.com/openstack-k8s-operators/dataplane-node-exporter/ovsdb/ovs"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/config"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/log"
+	"github.com/openstack-k8s-operators/openstack-network-exporter/ovsdb/ovs"
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
 	"github.com/ovn-org/libovsdb/ovsdb"


### PR DESCRIPTION
Due to conflicts in naming and the overloaded meaning for dataplane, the repo was renamed from dataplane-node-exporter to openstack-network-exporter.  This commit renames all relevant fields, variables, etc...