### PR TITLE
reldel: add github workflow for release management

### DIFF
--- a/.github/workflows/release-branch-sync.yaml
+++ b/.github/workflows/release-branch-sync.yaml
@@ -1,0 +1,12 @@
+name: Release Branch sync
+
+on:
+  push:
+    branches:
+      - '*'
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  call-build-workflow:
+    uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/release-branch-sync.yaml@main


### PR DESCRIPTION
Add the standard workflow to be included in downstream builds.